### PR TITLE
Change to usr/src prior to making cscope.out

### DIFF
--- a/workflow
+++ b/workflow
@@ -231,6 +231,7 @@ tools. While in bldenv, it will already be in your path as a program called
 via:
 
 ```
+$ cd usr/src
 $ dmake cscope.out
 $ cscope-fast -dq
 ```


### PR DESCRIPTION
User must cd to usr/src in order to make cscope.out. Otherwise, illumos doesn't know how to make cscope.out.